### PR TITLE
Update protocol-relative URLs to be HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <meta name="twitter:site" content="@philadelphiagov">
     <meta name="twitter:creator" content="@philadelphiagov">
     <meta property="og:type" content="website" />
-    <link rel="shortcut icon" type="image/x-icon" href="//s3.amazonaws.com/phila/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="https://s3.amazonaws.com/phila/favicon.ico">
     <meta property="og:url" content="http://analytics.phila.gov" />
     <link rel="canonical" href="http://analytics.phila.gov" />
 
@@ -56,19 +56,19 @@
 
     <!-- PUT A LITTLE STEEZ ON IT -->
     <link rel="stylesheet" href="/css/public_analytics.css">
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
     <!--pattern stylesheet includes foundation css -->
     <link rel="stylesheet" href="https://cityofphiladelphia.github.io/patterns/dist/0.6.0/css/patterns.css">
-    <link rel="stylesheet" href="//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
-    <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js?ver=2.8.3'></script>
+    <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
+    <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js?ver=2.8.3'></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>
     <!-- Google Tag Manager [phila.gov] -->
     <noscript>
-        <iframe src="//www.googletagmanager.com/ns.html?id=GTM-MC6CR2" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MC6CR2" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
     <script>
         (function (w, d, s, l, i) {
@@ -82,7 +82,7 @@
                 dl = l != 'dataLayer' ? '&l=' + l : '';
             j.async = true;
             j.src =
-                '//www.googletagmanager.com/gtm.js?id=' + i + dl;
+                'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
             f.parentNode.insertBefore(j, f);
         })(window, document, 'script', 'dataLayer', 'GTM-MC6CR2');
     </script>
@@ -235,7 +235,7 @@
                     </p>
 
                     <p>
-                        This dashboard uses code developed by the <a href="http://www.digitalgov.gov/services/dap/">Digital Analytics Program</a>, a US government team inside the <a href="http://www.gsa.gov">General Services Administration</a>, an independent federal agency. It was built largely by <a href="https://18f.gsa.gov/">18F</a>, another GSA team.
+                        This dashboard uses code developed by the <a href="https://www.digitalgov.gov/services/dap/">Digital Analytics Program</a>, a US government team inside the <a href="http://www.gsa.gov">General Services Administration</a>, an independent federal agency. It was built largely by <a href="https://18f.gsa.gov/">18F</a>, another GSA team.
 
                         This open source project is in the public domain, which means that this website and its data are free for you to use without restriction. You can find the <a href="https://github.com/CityofPhiladelphia/analytics.phila.gov">code for this website</a> and the <a href="https://github.com/18f/analytics-reporter">code behind the data collection</a> on GitHub.
                     </p>
@@ -350,9 +350,9 @@
       </div>
     </footer>
     <!-- End footer -->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.1/js/foundation.min.js"></script>
-    <script src="//cityofphiladelphia.github.io/patterns/dist/0.6.0/js/patterns.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.1/js/foundation.min.js"></script>
+    <script src="https://cityofphiladelphia.github.io/patterns/dist/0.6.0/js/patterns.min.js"></script>
     <script>
       $(document).foundation();
     </script>
@@ -378,13 +378,13 @@
     </script>
 
     <script src="/js/index.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.5.1/js/foundation.min.js"></script>
-    <script src="//cityofphiladelphia.github.io/patterns/dist/0.6.0/js/patterns.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/5.5.1/js/foundation.min.js"></script>
+    <script src="https://cityofphiladelphia.github.io/patterns/dist/0.6.0/js/patterns.min.js"></script>
     <script>
       $(document).foundation();
     </script>
-    <script src="http://d2g9qbzl5h49rh.cloudfront.net/static/feedback2.js?3.2.6760" type="text/javascript">
+    <script src="https://d2g9qbzl5h49rh.cloudfront.net/static/feedback2.js?3.2.6760" type="text/javascript">
 		var JFL_51087511490149 = new JotformFeedback({
 		formId:'51087511490149',
 		base:'http://jotform.us/',


### PR DESCRIPTION
Straightforward enough changes, and tested locally.

The Google Tag Manager setting [still needs to be tweaked](https://stackoverflow.com/a/23611744/16075) in the admin console to force the subsequent requests to GA's actual collection infrastructure. Only worth doing if the overall site's going to remain on `http://` for much longer.