### PR TITLE
fixes issue #13; use Gemfile/Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'sass'
+gem 'bourbon'
+gem 'neat'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bourbon (4.2.2)
+      sass (~> 3.4)
+      thor
+    neat (1.7.2)
+      bourbon (>= 4.0)
+      sass (>= 3.3)
+    sass (3.4.13)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bourbon
+  neat
+  sass

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collaboration to publish government website analytics.
 * Install [Sass](http://sass-lang.com/), Bourbon, and Neat:
 
 ```bash
-gem install sass bourbon neat
+bundle install
 ```
 
 * To watch the Sass source for changes and build the stylesheets automatically, run:


### PR DESCRIPTION
The Gemfile and Gemfile.lock can be used to lock the full, intended
dependency chain.
